### PR TITLE
feat: automatic recognition of plugin root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ mod test_mod {
 
 | Attribute | Description | Default |
 |-----------|-------------|---------|
-| `path`    | путь до директории плагина | Current directory |
+| `path`    | Путь до директории, содержащей файл топологии плагина ([topology.toml](https://github.com/picodata/pike?tab=readme-ov-file#topologytoml)) | Определяется автоматически |
 | `timeout` | Таймаут перед запуском первого теста (seconds) | 5 |
 
 # Управление кластером в Picotest
@@ -110,7 +110,8 @@ Picotest обеспечивает полную изоляцию тестовых
 ### Архитектура тестирования
 
 ```bash
-my_plugin/
+my_pike_plugin/
+├── topology.toml    # Файл топологии плагина
 ├── src/
 │   └── lib.rs       # Основной код
 └── tests/

--- a/picotest/src/lib.rs
+++ b/picotest/src/lib.rs
@@ -1,5 +1,6 @@
 pub use std::{sync::OnceLock, time::Duration};
 
+use internal::plugin_root_dir;
 pub use picotest_helpers::Cluster;
 pub use picotest_macros::*;
 pub mod internal;
@@ -9,11 +10,20 @@ pub use std::panic;
 pub static SESSION_CLUSTER: OnceLock<Cluster> = OnceLock::new();
 
 #[fixture]
-pub fn cluster(#[default(".")] plugin_path: &str, #[default(5)] timeout: u64) -> &'static Cluster {
+pub fn cluster(
+    #[default(None)] plugin_path: Option<&str>,
+    #[default(5)] timeout_secs: u64,
+) -> &'static Cluster {
     SESSION_CLUSTER.get_or_init(|| {
-        let timeout = Duration::from_secs(timeout);
-        Cluster::new(plugin_path, timeout)
-            .expect("Failed to parse topology")
+        let timeout = Duration::from_secs(timeout_secs);
+        // Look up plugin root directory automatically
+        // unless explicitly specified.
+        let plugin_path = match plugin_path {
+            None => plugin_root_dir().to_string_lossy().into_owned(),
+            Some(path) => path.to_string(),
+        };
+        Cluster::new(&plugin_path, timeout)
+            .expect("Failed to create the cluster")
             .run()
             .expect("Failed to start the cluster")
     })

--- a/picotest/tests/assets/picotest_macro_tests.rs
+++ b/picotest/tests/assets/picotest_macro_tests.rs
@@ -1,0 +1,13 @@
+//! Tests for #\[picotest\] macro
+//!
+//! They are expected to be executed inside plugin
+//! workspace.
+//!
+
+use rstest::rstest;
+use picotest::*;
+
+#[picotest]
+fn test_integration_test_inside_plugin() {
+    println!("Hello from integration_test_inside_plugin");
+}

--- a/picotest/tests/test_integration_inside_plugin.rs
+++ b/picotest/tests/test_integration_inside_plugin.rs
@@ -1,0 +1,28 @@
+mod helpers;
+
+use constcat::concat;
+use helpers::{
+    add_source_file_to_plugin, fresh_plugin, run_cargo_test_in_plugin_workspace, LineMatcher,
+    TestPlugin,
+};
+use rstest::rstest;
+
+const TEST_SOURCE_MODULE_NAME: &str = "picotest_macro_tests";
+const TEST_SOURCE_FILE_PATH: &str = concat!(TEST_SOURCE_MODULE_NAME, ".rs");
+
+#[rstest]
+fn run_integration_tests_inside_plugin_workspace(fresh_plugin: &TestPlugin) {
+    add_source_file_to_plugin(fresh_plugin, asset!(TEST_SOURCE_FILE_PATH).into());
+    let mut line_matcher = LineMatcher::new("Hello from integration_test_inside_plugin");
+    let exit_status = run_cargo_test_in_plugin_workspace(
+        &fresh_plugin.path,
+        TEST_SOURCE_MODULE_NAME,
+        &mut line_matcher,
+    );
+
+    assert!(
+        exit_status.success(),
+        "tests are supposed to finish successfully"
+    );
+    assert!(line_matcher.has_matched());
+}

--- a/picotest/tests/test_unit.rs
+++ b/picotest/tests/test_unit.rs
@@ -1,13 +1,15 @@
 mod helpers;
 
 use constcat::concat;
-use helpers::{fresh_plugin, run_cargo_test_in_plugin_workspace, LineMatcher, TestPlugin};
+use helpers::{
+    add_source_file_to_plugin, fresh_plugin, run_cargo_test_in_plugin_workspace, LineMatcher,
+    TestPlugin,
+};
 use rstest::rstest;
-use std::io::Write;
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 const TEST_SOURCE_MODULE_NAME: &str = "picotest_unit_macro_tests";
-const TEST_SOURCE_FILE_PATH: &str = concat!("./tests/assets/", TEST_SOURCE_MODULE_NAME, ".rs");
+const TEST_SOURCE_FILE_PATH: &str = concat!(TEST_SOURCE_MODULE_NAME, ".rs");
 
 // Run tests that's supposed to finish with success.
 fn assert_success_tests(plugin_path: &PathBuf) {
@@ -38,26 +40,8 @@ fn assert_failed_tests(plugin_path: &PathBuf) {
 }
 
 #[rstest]
-fn tests(fresh_plugin: &TestPlugin) {
-    let plugin_sources = fresh_plugin.path.join("src");
-    let test_source_path = PathBuf::from(TEST_SOURCE_FILE_PATH);
-    let test_source_filename = test_source_path.file_name().unwrap();
-
-    // Copy *.rs source file with tests to plugin directory.
-    fs::copy(&test_source_path, plugin_sources.join(test_source_filename))
-        .expect("Failed to copy test file to plugin directory");
-
-    // Add test module to test plugin library.
-    // This is necessary to run tests using "cargo test".
-    {
-        let mut lib_rs = fs::OpenOptions::new()
-            .append(true)
-            .open(plugin_sources.join("lib.rs"))
-            .expect("Failed to open plugin lib.rs");
-
-        writeln!(lib_rs, "\nmod {TEST_SOURCE_MODULE_NAME};")
-            .expect("Failed to add test module to lib.rs");
-    }
+fn run_unit_tests_inside_plugin_workspace(fresh_plugin: &TestPlugin) {
+    add_source_file_to_plugin(fresh_plugin, asset!(TEST_SOURCE_FILE_PATH).into());
 
     assert_success_tests(&fresh_plugin.path);
     assert_failed_tests(&fresh_plugin.path);

--- a/picotest_macros/src/utils.rs
+++ b/picotest_macros/src/utils.rs
@@ -1,7 +1,8 @@
+use quote::quote;
 use syn::{parse_quote, Attribute, FnArg, ItemFn, Stmt};
 const TEST_PREFIX: &str = "test_";
 
-pub fn process_test_function(mut func: ItemFn, path: &String, timeout: u64) -> ItemFn {
+pub fn process_test_function(mut func: ItemFn, path: &Option<String>, timeout: u64) -> ItemFn {
     let func_name = func.sig.ident.to_string();
     if !func_name.starts_with(TEST_PREFIX) {
         return func;
@@ -9,6 +10,11 @@ pub fn process_test_function(mut func: ItemFn, path: &String, timeout: u64) -> I
 
     let rstest_macro: Attribute = parse_quote! { #[rstest] };
     func.attrs.insert(0, rstest_macro);
+
+    let path = match path {
+        Some(cfg_path) => quote! { Some(#cfg_path) },
+        None => quote! { None },
+    };
 
     let cluster: FnArg = parse_quote! {
         #[with(#path, #timeout)] cluster: &Cluster


### PR DESCRIPTION
picotest macros now automatically look for plugin root directory unless specified explicitly through macro attributes (in case of #[picotest]).

closes #22