### PR TITLE
fix(tests): change service name in tests to "example_service"

### DIFF
--- a/picotest/tests/helpers.rs
+++ b/picotest/tests/helpers.rs
@@ -12,7 +12,7 @@ use wait_timeout::ChildExt;
 const TMP_DIR: &str = "../tmp/";
 const PLUGIN_NAME: &str = "test_plugin";
 const PLUGIN_DIR: &str = concat!(TMP_DIR, PLUGIN_NAME);
-const PLUGIN_SERVICE_NAME: &str = "main";
+const PLUGIN_SERVICE_NAME: &str = "example_service";
 const PROCESS_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const TESTS_EXECUTION_TIMELIMIT: Duration = Duration::from_secs(1200);
 

--- a/picotest/tests/test_integration.rs
+++ b/picotest/tests/test_integration.rs
@@ -119,7 +119,7 @@ pub struct ExampleResponse {
 
 #[tokio::test]
 #[picotest(path = "../tmp/test_plugin")]
-async fn test_rpc_handle() {
+async fn test_rpc_handle(plugin: &TestPlugin) {
     let user_to_send = User {
         name: "Dodo".to_string(),
     };
@@ -127,9 +127,9 @@ async fn test_rpc_handle() {
     let tnt_response = cluster
         .main()
         .execute_rpc::<User, ExampleResponse>(
-            "test_plugin",
+            &plugin.name,
             "/greetings_rpc",
-            "main",
+            &plugin.service_name,
             "0.1.0",
             &user_to_send,
         )


### PR DESCRIPTION
Pike has changed example plugin service name in 2.4.3. Adjust tests to use updated service name.