### PR TITLE
chore: bump picodata from 25.1.1 to 25.1.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     container:
-      image: docker.binary.picodata.io/picodata:25.1.1
+      image: docker.binary.picodata.io/picodata:25.1.2
       options: --user root
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Merge after the new version of Pike is released