### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.0]
+
+### Added
+
+* Run all migrations on default tier when unit tests are used
+
+
 ## [1.5.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "picotest"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "constcat",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "picotest_helpers"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "picotest_macros"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/picotest/Cargo.toml
+++ b/picotest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picotest"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 license = "BSD-2-Clause"
 description = "Test framework for Picodata plugin"

--- a/picotest_helpers/Cargo.toml
+++ b/picotest_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picotest_helpers"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 license = "BSD-2-Clause"
 description = "Test framework for Picodata plugin"

--- a/picotest_macros/Cargo.toml
+++ b/picotest_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picotest_macros"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 license = "BSD-2-Clause"
 description = "Test framework for Picodata plugin"


### PR DESCRIPTION
## [1.6.0]

### Added

* Run all migrations on default tier when unit tests are used (bb81378448ffdfd2b119ff47bb18d586395ecc38)

