### PR TITLE
chore(deps): bump picodata-pike from 5.3.0 to 5.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "picodata-pike"
-version = "5.3.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c1a3aa31191bf37fa7465e2a2d7e69ad3c3ef3b11ea372709fec308af40cef"
+checksum = "6d56c4cb9a9129ed11fbfedcffdf7c1009d29f97cb281e5e96f6fd9ba028bb97"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [workspace.dependencies]
 anyhow = { version = "1.0.102" }
-picodata-pike = { version = "^5.3.0" }
+picodata-pike = { version = "^5.3.1" }
 rstest = { version = "0.26.1"}
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = { version = "0.9.34-deprecated" }


### PR DESCRIPTION
Fixed MacOS compatibility issue in pike 5.3.1.