### PR TITLE
Prepare release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.3]
+
+### Changed
+
+* Bump pike to 5.3.2
+* Replace unmaintained serde_yaml with maintained fork [serde_norway](https://github.com/cafkafk/serde-norway)
+
 ## [3.1.2]
 
 ### Changed
 
 * Bump pike to 5.3.1
-
 
 ## [3.1.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "picodata-pike"
-version = "5.3.1"
+version = "5.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d56c4cb9a9129ed11fbfedcffdf7c1009d29f97cb281e5e96f6fd9ba028bb97"
+checksum = "4ad97e9e78f989aedd69c822328c747e7ae4396a47ea57e15503f3ad9e1c72ba"
 dependencies = [
  "anyhow",
  "clap",
@@ -1421,11 +1421,11 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "tar",
  "terminal_size",
  "toml",
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
  "ureq",
 ]
 
@@ -1444,7 +1444,7 @@ dependencies = [
  "rmp-serde",
  "rstest",
  "serde",
- "serde_yaml",
+ "serde_norway",
  "tokio",
  "uuid",
  "wait-timeout",
@@ -1995,25 +1995,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2333,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -2399,10 +2399,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ anyhow = { version = "1.0.102" }
 picodata-pike = { version = "^5.3.1" }
 rstest = { version = "0.26.1"}
 serde = { version = "1.0.228", features = ["derive"] }
-serde_yaml = { version = "0.9.34-deprecated" }
+serde_norway = { version = "0.9" }
 rmp-serde = { version = "^1.1" }
 env_logger = "0.11.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [workspace.dependencies]
 anyhow = { version = "1.0.102" }
-picodata-pike = { version = "^5.3.1" }
+picodata-pike = { version = "^5.3.2" }
 rstest = { version = "0.26.1"}
 serde = { version = "1.0.228", features = ["derive"] }
 serde_norway = { version = "0.9" }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
     - [Использование `#[picotest]`](#использование-picotest)
     - [Переменные окружения](#переменные-окружения)
       - [`WAIT_VSHARD_DISCOVERY`](#wait_vshard_discovery)
-      - [Логирование](#логирование)
-      - [`RUST_LOG`](#rust_log)
+    - [Логирование](#логирование)
+    - [Файлы логов кластера](#файлы-логов-кластера)
     - [Совместимость с `rstest`](#совместимость-с-rstest)
     - [Атрибуты макроса `#[picotest]`](#атрибуты-макроса-picotest)
     - [Применение конфигурации плагина к запущенному кластеру Picodata](#применение-конфигурации-плагина-к-запущенному-кластеру-picodata)
@@ -249,7 +249,7 @@ fn test_apply_plugin() {
         "#;
 
     let plugin_config: PluginConfigMap = 
-        serde_yaml::from_str(plugin_config_yaml).unwrap();
+        serde_norway::from_str(plugin_config_yaml).unwrap();
 
     // 2. Apply config to the running cluster instance.
 

--- a/picotest/Cargo.toml
+++ b/picotest/Cargo.toml
@@ -36,5 +36,5 @@ tokio = "1.52.3"
 wait-timeout = "0.2.1"
 uuid = { version = "1.23.2", features = ["v4"] }
 constcat = "0.6.1"
-serde_yaml = "0.9.34"
+serde_norway.workspace=true
 postgres = { version = "0.19", features = ["with-chrono-0_4"] }

--- a/picotest/tests/test_integration.rs
+++ b/picotest/tests/test_integration.rs
@@ -36,7 +36,7 @@ fn test_apply_config(plugin: &TestPlugin) {
     let must_be_overriden = "should_be_overridden_after_apply";
     let service_config = HashMap::from([(
         "value".to_string(),
-        serde_yaml::to_value(must_be_overriden).unwrap(),
+        serde_norway::to_value(must_be_overriden).unwrap(),
     )]);
     let plugin_config = HashMap::from([(plugin.service_name.clone(), service_config)]);
 
@@ -195,7 +195,7 @@ fn test_run_lua_select_and_serialize_output_from_yaml() {
     }
 
     let actual: Vec<Vec<SomeStruct>> =
-        serde_yaml::from_str(&output).expect("Failed to deserialize struct from YAML string");
+        serde_norway::from_str(&output).expect("Failed to deserialize struct from YAML string");
 
     assert_eq!(
         actual,

--- a/picotest_helpers/src/lib.rs
+++ b/picotest_helpers/src/lib.rs
@@ -408,13 +408,13 @@ impl Cluster {
     ///
     /// **1. Using YAML formatted string.**
     ///
-    /// Put desired config inside string and deserialize it using [`serde_yaml::from_str`]. Then attach it to
+    /// Put desired config inside string and deserialize it using [`serde_norway::from_str`]. Then attach it to
     /// a particular plugin service.
     ///
     /// ```rust,ignore
     /// use rmpv::Value;
     /// use std::collections::HashMap;
-    /// use serde_yaml::Value;
+    /// use serde_norway::Value;
     /// use picotest::*;
     ///
     /// #[picotest]
@@ -429,7 +429,7 @@ impl Cluster {
     ///         "#;
     ///
     ///     let plugin_config: PluginConfigMap =
-    ///         serde_yaml::from_str(plugin_config_yaml).unwrap();
+    ///         serde_norway::from_str(plugin_config_yaml).unwrap();
     ///
     ///     // 2. Apply config to the running cluster instance.
     ///
@@ -444,12 +444,12 @@ impl Cluster {
     ///
     /// **2. Using `HashMap`.
     ///
-    /// Config can be assembled by means of [`std::collections::HashMap`] and [`serde_yaml::to_str`].
+    /// Config can be assembled by means of [`std::collections::HashMap`] and [`serde_norway::to_str`].
     ///
     /// ```rust,ignore
     /// use rmpv::Value;
     /// use std::collections::HashMap;
-    /// use serde_yaml::Value;
+    /// use serde_norway::Value;
     /// use picotest::*;
     ///
     /// #[picotest]
@@ -479,7 +479,7 @@ impl Cluster {
     ///
     /// #### Plugin with single service called `router`, which has nested properties for RPC machinery.
     ///
-    /// Nested sections in config mapping are handled similarly. We just need to wrap nested map value into [`serde_yaml::Value`].
+    /// Nested sections in config mapping are handled similarly. We just need to wrap nested map value into [`serde_norway::Value`].
     ///
     /// Assume [plugin YAML configuration file](https://github.com/picodata/pike?tab=readme-ov-file#config-apply)
     /// has the following mapping:
@@ -497,7 +497,7 @@ impl Cluster {
     /// ```rust,ignore
     /// use rmpv::Value;
     /// use std::collections::HashMap;
-    /// use serde_yaml::Value;
+    /// use serde_norway::Value;
     /// use picotest::*;
     ///
     /// #[picotest]
@@ -509,7 +509,7 @@ impl Cluster {
     ///         ("max_message_queue_size".to_string(), Value::Number(32.into())),
     ///     ]);
     ///
-    ///     let router_config = HashMap::from([("rpc".to_string(), serde_yaml::to_value(rpc_config).unwrap())]);
+    ///     let router_config = HashMap::from([("rpc".to_string(), serde_norway::to_value(rpc_config).unwrap())]);
     ///     let plugin_config = HashMap::from([("router".to_string(), router_config)]);
     ///
     ///     cluster // implicitly created variable by picotest magic


### PR DESCRIPTION
Sonar cube doesn't allow unmaintained crates to be included into Cargo.toml. So replaced deprecated serde_yaml with [serde_norway](https://github.com/cafkafk/serde-norway). Bumped pike to 5.3.2.